### PR TITLE
Handle answers passed to inquirer.prompt

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,9 +17,9 @@ function mockInquirer (fills) {
   let origPrompt = inquirer.prompt
 
   // 对 inquirer 的 prompt 进行 mock
-  inquirer.prompt = function (fields) {
+  inquirer.prompt = function (fields, answers) {
     let mocks = fills.shift() || {}
-    let answers = {}
+    answers = answers || {}
 
     fields.forEach(field => {
       if (field.when === undefined || (field.when && (typeof field.when !== 'function' || field.when(answers)))) {
@@ -29,7 +29,9 @@ function mockInquirer (fills) {
           }
         }
 
-        answers[field.name] = mocks.hasOwnProperty(field.name) ? mocks[field.name] : getDefault(field.default)
+        if (answers[field.name] === undefined) {
+          answers[field.name] = mocks.hasOwnProperty(field.name) ? mocks[field.name] : getDefault(field.default)
+        }
       }
     })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -105,4 +105,31 @@ describe('test mock inquirer', function () {
       reset();
     }
   })
+
+  it('should handle answers already given to inquirer', function* () {
+    let reset = mockInquirer([{
+        hello: 'world'  // will auto fill 'world'
+    }]);
+
+    try {
+      let anwsers = yield inquirer.prompt([{
+        type: 'input',
+        message: 'I say hello, you say:',
+        name: 'hello'
+      },
+      {
+        type: 'confirm',
+        message: 'mock inquirer is awesome:',
+        name: 'like'
+      }],
+      {
+        like: true
+      })
+
+        assert.equal(anwsers.hello, "world");
+        assert.equal(anwsers.like, true);
+    } finally {
+      reset();
+    }
+  })
 })


### PR DESCRIPTION
Inquirer.prompt takes two arguments, questions and answers. Right now mock-inquirer only handles questions, but with this fix you can pass answers to prompt and they will have higher prio than mocked answers, which mimics the inquirer behavior.